### PR TITLE
Change resource to published

### DIFF
--- a/DragonRuby-API-Documentation.md
+++ b/DragonRuby-API-Documentation.md
@@ -2,7 +2,7 @@
 title: DragonRuby API Documentation
 desc: Listing of methods and objects available in the engine.
 layout: default
-resource: true
+published: true
 categories: [Docs]
 ---
 

--- a/abc-tutorial-for-new-programmers.md
+++ b/abc-tutorial-for-new-programmers.md
@@ -2,7 +2,7 @@
 title: ABC Tutorial for New Programmers
 desc: This tutorial assumes that you have never programmed before.
 layout: default
-resource: true
+published: true
 categories: [Tutorials]
 ---
 

--- a/cheatsheet-and-faq.md
+++ b/cheatsheet-and-faq.md
@@ -2,7 +2,7 @@
 title: Cheatsheet & FAQ
 desc: Tips and Tricks to tame the Dragon.
 layout: default
-resource: true
+published: true
 categories: [Tutorials]
 ---
 

--- a/code-blocks.md
+++ b/code-blocks.md
@@ -2,7 +2,7 @@
 title: Code Blocks
 desc: Short, but powerful, drop-in code segments.
 layout: default
-resource: true
+published: true
 categories: [Tutorials]
 ---
 

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 title: Ruby for Dragons
 desc: An unofficial companion to the DragonRuby documentation.
 layout: default
-resource: true
+published: true
 categories: [Wiki]
 ---
 
@@ -44,4 +44,4 @@ This wiki is a consolidation of the community coming together to organize those 
 
 The “Ruby on Wings” page was originally contributed by Kniknoo, and does an excellent job onboarding new Dragonriders. Other contributions are credited above each page/code block.
 
-The wiki is hosted through Github Pages, and therefore uses Jekyll to serve content. There is an unplubilished template page in the root of the github repo. Copy the template to a new file and change `resource: ` to `true` to publish the page. New pages are automatically indexed in the sitemap. You can view the "compiled" template [here](https://ejectdrive.com/Ruby_for_Dragons/template).
+The wiki is hosted through Github Pages, and therefore uses Jekyll to serve content. There is an unplubilished template page in the root of the github repo. Copy the template to a new file and change published: ` to `true` to publish the page. New pages are automatically indexed in the sitemap. You can view the "compiled" template [here](https://ejectdrive.com/Ruby_for_Dragons/template).

--- a/ruby-on-wings.md
+++ b/ruby-on-wings.md
@@ -2,7 +2,7 @@
 title: Ruby on Wings
 desc: This tutorial is for programmers new to DragonRuby.
 layout: default
-resource: true
+published: true
 categories: [Tutorials]
 ---
 

--- a/sitemap.md
+++ b/sitemap.md
@@ -2,7 +2,7 @@
 title: Sitemap
 desc: A full listing of published pages on the wiki.
 layout: default
-resource: true
+published: true
 categories: [Wiki]
 ---
 {% include header.html %}
@@ -11,7 +11,7 @@ categories: [Wiki]
 ### {{ cat }}
 <ul>
 {% for page in site.pages %}
-{% if page.resource == true %}
+{% if page.published == true %}
 {% for pc in page.categories %}
 {% if pc == cat %}
 <li>
@@ -19,7 +19,7 @@ categories: [Wiki]
 </li>
 {% endif %} <!-- cat-match-p -->
 {% endfor %} <!-- page-category -->
-{% endif %} <!-- resource-p -->
+{% endif %} <!-- published-p -->
 {% endfor %} <!-- page -->
 </ul>
 {% endfor %} <!-- cat -->

--- a/template.md
+++ b/template.md
@@ -2,7 +2,7 @@
 title: Sample Page
 desc: A sample description of the Sample Page
 layout: default
-resource: false
+published: false
 categories: [Docs, Tutorials, Wiki]
 ---
 


### PR DESCRIPTION
No reason for pages to say `resource: ' when they can say 'published: '